### PR TITLE
Use sandbox for privilege separation

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -169,7 +169,7 @@ class ssh_hardening::server (
 
       # Secure Login directives.
       'UseLogin'                        => 'no',
-      'UsePrivilegeSeparation'          => 'yes',
+      'UsePrivilegeSeparation'          => 'sandbox',
       'PermitUserEnvironment'           => 'no',
       'LoginGraceTime'                  => '30s',
       'MaxAuthTries'                    => 2,


### PR DESCRIPTION
As per https://wiki.mozilla.org/Security/Guidelines/OpenSSH#Modern_.28OpenSSH_6.7.2B.29
